### PR TITLE
add issusanconcerned flag

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,34 @@
+---
+layout: default
+---
+
+<div class="home">
+  {%- if page.title -%}
+    <h1 class="page-heading">{{ page.title }}</h1>
+  {%- endif -%}
+
+  {{ content }}
+
+  {%- if site.posts.size > 0 -%}
+    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
+    <ul class="post-list">
+      {%- for post in site.posts -%}
+      <li>
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        <h3>
+          <b>{{ post.issusanconcerned }}</b>: <a class="post-link-inline" href="{{ post.url | relative_url }}">
+            {{ post.title | escape }}
+          </a>
+        </h3>
+        {%- if site.show_excerpts -%}
+          {{ post.excerpt }}
+        {%- endif -%}
+      </li>
+      {%- endfor -%}
+    </ul>
+
+    <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+  {%- endif -%}
+
+</div>

--- a/_posts/2020-07-09-berman-testimony.markdown
+++ b/_posts/2020-07-09-berman-testimony.markdown
@@ -2,6 +2,7 @@
 layout: post
 title:  "Former US Attorney for SDNY testifies he was pressured to resign?"
 date:   2020-07-09 18:53:00 -0400
+issusanconcerned: "No"
 ---
 # No.
 

--- a/_posts/2020-07-10-stone-pardon.markdown
+++ b/_posts/2020-07-10-stone-pardon.markdown
@@ -2,6 +2,7 @@
 layout: post
 title:  "President Trump commutes sentence for Roger Stone?"
 date:   2020-07-10 18:53:00 -0400
+issusanconcerned: "No"
 ---
 # No.
 

--- a/_posts/2020-07-13-fauci-undercut.markdown
+++ b/_posts/2020-07-13-fauci-undercut.markdown
@@ -2,6 +2,7 @@
 layout: post
 title:  "White House works to undercut Dr. Fauci?"
 date:   2020-07-13 15:44:00 -0400
+issusanconcerned: "No"
 ---
 # No.
 

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,0 +1,8 @@
+---
+---
+@import "{{ site.theme }}";
+
+/* Same as the main theme's post link, but not display block */
+.post-link-inline {
+  @include relative-font-size(1.5);
+}


### PR DESCRIPTION
This PR adds an `issusanconcerned` flag to each post, so that it can easily be displayed on the front page. It doesn't do anything fancy with it, but just tries to do the minimal to make it basically usable.

Helpful docs on customizing the theme:

* https://jekyllrb.com/docs/themes/#overriding-theme-defaults
* https://docs.github.com/en/enterprise/2.14/user/articles/customizing-css-and-html-in-your-jekyll-theme
* https://jekyllrb.com/docs/step-by-step/07-assets/

<img width="873" alt="Is Susan Collins concerned about it? | Part of the Susan Collins Webring of Concern  2020-07-13 16-45-07" src="https://user-images.githubusercontent.com/7150/87351926-395d4900-c528-11ea-8dda-4bad4a5eaf03.png">
